### PR TITLE
Fix Excel generation error

### DIFF
--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -29,10 +29,14 @@ def main():
     logging.info("HTML report generated → %s", args.output_html)
 
     if args.excel:
-        with pd.ExcelWriter(args.excel) as xls:
-            ctx["buy_summary"].to_excel(xls, "BUY",  index=False)
-            ctx["sell_summary"].to_excel(xls, "SELL", index=False)
-            ctx["best_routes"].to_excel(xls, "ROUTES", index=False)
+        try:
+            buy_df  = pd.DataFrame(ctx.get("buy_summary", []))
+            sell_df = pd.DataFrame(ctx.get("sell_summary", []))
+            with pd.ExcelWriter(args.excel) as xls:
+                buy_df.to_excel(xls, "BUY", index=False)
+                sell_df.to_excel(xls, "SELL", index=False)
+        except Exception as exc:
+            logging.error("Failed to write Excel report: %s", exc)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- fix excel output when buy/sell summaries aren't DataFrames
- guard against errors when generating Excel report
- remove nonexistent `best_routes` usage
- run flake8 for style checks

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6865b2327ce48329928e538f11c02152