### PR TITLE
Add simple test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@ Open-source Python web dashboard that parses Star Citizen logs to visualize trad
 
 A lightweight, Flask-powered web app that turns raw Star Citizen log files into an interactive trading dashboard.
 The backend ingests your logs\Session files, computes buy/sell metrics, route profitability, and commodity price evolution with pandas; the frontend (Plotly/Dash) renders live charts, tables, and KPIs so haulers and miners can spot the most lucrative loops at a glance. Fully containerized, cross-platform, and ready for self-hosting
+## Testing
+Place your game log files inside `tests/logs/` and run:
+\n```bash\npython tests/test_pipeline.py\n```
+This will parse the logs and print computed KPIs.

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,27 @@
+"""Utility script to run the log parsing and analysis pipeline."""
+
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import pandas as pd
+
+from app.log_parser import collect_files, iter_records
+from app.analysis import analyse
+
+DEFAULT_LOG_DIR = Path(__file__).parent / "logs"
+
+
+def run_pipeline(log_dir: Path = DEFAULT_LOG_DIR) -> dict:
+    files = collect_files([str(log_dir)])
+    if not files:
+        raise FileNotFoundError(f"No .log files found in {log_dir}")
+    df = pd.DataFrame(iter_records(files))
+    ctx = analyse(df)
+    print("KPIs", ctx.get("kpi"))
+    return ctx
+
+
+if __name__ == "__main__":
+    import sys
+    log_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_LOG_DIR
+    run_pipeline(log_dir)


### PR DESCRIPTION
## Summary
- add `tests` directory with placeholder log folder
- add script `tests/test_pipeline.py` to run the parser and analysis
- document how to run the test script in README

## Testing
- `python tests/test_pipeline.py` *(fails: No .log files found)*

------
https://chatgpt.com/codex/tasks/task_e_6865ca7d01908329a14b95e48f79ad10