### PR TITLE
Implement best routes and pending inventory

### DIFF
--- a/app/web/static/main.js
+++ b/app/web/static/main.js
@@ -35,8 +35,10 @@ ws.onmessage = evt => {
   }
 
   // Tables helper
-  populateTable("buyTable",  data.buy_summary);
-  populateTable("sellTable", data.sell_summary);
+  populateTable("buyTable",    data.buy_summary);
+  populateTable("sellTable",   data.sell_summary);
+  populateTable("routeTable",  data.best_routes);
+  populateTable("pendingTable", data.pending_goods);
 };
 
 function set(id, txt) { document.getElementById(id).textContent = txt; }

--- a/app/web/templates/dashboard.html
+++ b/app/web/templates/dashboard.html
@@ -33,6 +33,14 @@
     <h2>Sell Summary</h2>
     <table id="sellTable" class="data-table"></table>
   </section>
+  <section>
+    <h2>Best Routes</h2>
+    <table id="routeTable" class="data-table"></table>
+  </section>
+  <section>
+    <h2>Pending Inventory</h2>
+    <table id="pendingTable" class="data-table"></table>
+  </section>
 
   <script src="/static/main.js"></script>
 </body>

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -33,6 +33,7 @@ def main():
             ctx["buy_summary"].to_excel(xls, "BUY",  index=False)
             ctx["sell_summary"].to_excel(xls, "SELL", index=False)
             ctx["best_routes"].to_excel(xls, "ROUTES", index=False)
+            ctx["pending_goods"].to_excel(xls, "PENDING", index=False)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- compute best trading routes and pending inventory
- expose results in web API and HTML templates
- show routes and pending items in dashboard tables
- export new metrics to Excel in CLI report

## Testing
- `python3 -m py_compile app/*.py scripts/generate_report.py`

------
https://chatgpt.com/codex/tasks/task_e_6865b706d9a0832989e643b97e074eff