### PR TITLE
Add basic setup docs and task list

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,20 @@ Open-source Python web dashboard that parses Star Citizen logs to visualize trad
 
 A lightweight, Flask-powered web app that turns raw Star Citizen log files into an interactive trading dashboard.
 The backend ingests your logs\Session files, computes buy/sell metrics, route profitability, and commodity price evolution with pandas; the frontend (Plotly/Dash) renders live charts, tables, and KPIs so haulers and miners can spot the most lucrative loops at a glance. Fully containerized, cross-platform, and ready for self-hosting
+
+## Getting Started
+
+1. Install dependencies
+```bash
+pip install -r requirements.txt
+```
+
+2. Run the API locally
+```bash
+uvicorn app.web.main:app --reload
+```
+
+3. Generate an HTML report from logs
+```bash
+python scripts/generate_report.py path/to/logs/*.log report.html
+```

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,19 @@
+# Development Tasks
+
+## 1. Package dependencies
+- [ ] Create a `requirements.txt` listing packages: `fastapi`, `uvicorn`, `pandas`, `matplotlib`, and `jinja2`.
+- [ ] Reference this file in the README for setup instructions.
+
+## 2. Add automated tests
+- [ ] Add unit tests using `pytest` for `log_parser` and `analysis` functions.
+- [ ] Configure GitHub Actions or another CI to run the tests.
+
+## 3. Improve README
+- [ ] Document how to run the web application with `uvicorn`.
+- [ ] Include example commands to generate reports using `scripts/generate_report.py`.
+
+## 4. Address warnings
+- [ ] Update FastAPI startup events to use lifespan handlers instead of deprecated `on_event`.
+
+## 5. Sample data
+- [ ] Provide example Star Citizen log files in a `sample-data` directory for testing and documentation.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+pandas
+matplotlib
+jinja2


### PR DESCRIPTION
## Summary
- add `requirements.txt`
- document setup in README
- create initial `TASKS.md`

## Testing
- `pip check`
- `python -m app.web.main` (server started then terminated)

------
https://chatgpt.com/codex/tasks/task_e_6865d12b46fc8329995f3b244adff4bd