### PR TITLE
Add report generation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,17 @@ uvicorn app.web.main:app --reload
 ```bash
 python scripts/generate_report.py path/to/logs/*.log report.html
 ```
+
+## Report Generation Examples
+
+Generate an HTML report from the bundled sample logs:
+
+```bash
+python scripts/generate_report.py sample-data/*.log sample-report.html
+```
+
+Generate both HTML and Excel reports from an entire log directory:
+
+```bash
+python scripts/generate_report.py sample-data report.html --excel report.xlsx
+```

--- a/app/report.py
+++ b/app/report.py
@@ -11,12 +11,7 @@ def fig_to_b64(fig) -> str:
     plt.close(fig)
     return base64.b64encode(buf.getvalue()).decode()
 
-<<<<<<< HEAD
-
-HTML_TEMPLATE = Path(__file__).with_name("templates") / "dashboard.html"
-=======
 HTML_TEMPLATE = Path(__file__).parent / "web" / "templates" / "dashboard.html"
->>>>>>> origin/codex/update-template-path-in-report.py
 
 
 def render_html(ctx: dict, dst: Path):


### PR DESCRIPTION
## Summary
- fix merge leftover in `report.py`
- document how to run `generate_report.py` to create HTML and Excel reports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d4f5d14c8329be6694cd4941a4b6