### PR TITLE
Add CI workflow for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: |
+          pytest -q

--- a/app/report.py
+++ b/app/report.py
@@ -11,12 +11,7 @@ def fig_to_b64(fig) -> str:
     plt.close(fig)
     return base64.b64encode(buf.getvalue()).decode()
 
-<<<<<<< HEAD
-
-HTML_TEMPLATE = Path(__file__).with_name("templates") / "dashboard.html"
-=======
 HTML_TEMPLATE = Path(__file__).parent / "web" / "templates" / "dashboard.html"
->>>>>>> origin/codex/update-template-path-in-report.py
 
 
 def render_html(ctx: dict, dst: Path):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -25,3 +25,8 @@ if __name__ == "__main__":
     import sys
     log_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_LOG_DIR
     run_pipeline(log_dir)
+
+
+def test_pipeline_sample_data():
+    ctx = run_pipeline(Path("sample-data"))
+    assert ctx["kpi"]["total_buys"] >= 0


### PR DESCRIPTION
## Summary
- fix unresolved merge conflict in `report.py`
- add sample data test for pipeline
- set up GitHub Actions workflow to run tests on pushes and PRs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865d4e96a848329ab36dcf9b06548b3