### PR TITLE
Fix static dashboard rendering

### DIFF
--- a/app/report.py
+++ b/app/report.py
@@ -2,6 +2,7 @@ import io
 import base64
 from pathlib import Path
 from jinja2 import Template
+import json
 import matplotlib.pyplot as plt
 
 
@@ -15,5 +16,7 @@ HTML_TEMPLATE = Path(__file__).parent / "web" / "templates" / "dashboard.html"
 
 
 def render_html(ctx: dict, dst: Path):
+    """Render dashboard template with embedded JSON context."""
     template = Template(HTML_TEMPLATE.read_text(encoding="utf-8"))
-    dst.write_text(template.render(**ctx), encoding="utf-8")
+    html = template.render(ctx_json=json.dumps(ctx))
+    dst.write_text(html, encoding="utf-8")

--- a/app/web/static/main.js
+++ b/app/web/static/main.js
@@ -1,9 +1,6 @@
-const wsUrl = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`;
-const ws = new WebSocket(wsUrl);
 let chart;
 
-ws.onmessage = evt => {
-  const data = JSON.parse(evt.data);
+function updateDashboard(data) {
   if (!data.kpi) return; // bootstrap state
 
   // KPI widgets
@@ -39,7 +36,16 @@ ws.onmessage = evt => {
   populateTable("sellTable",   data.sell_summary);
   populateTable("routeTable",  data.best_routes);
   populateTable("pendingTable", data.pending_goods);
-};
+}
+
+const initEl = document.getElementById('init-data');
+if (initEl) {
+  updateDashboard(JSON.parse(initEl.textContent));
+} else {
+  const wsUrl = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`;
+  const ws = new WebSocket(wsUrl);
+  ws.onmessage = evt => updateDashboard(JSON.parse(evt.data));
+}
 
 function set(id, txt) { document.getElementById(id).textContent = txt; }
 

--- a/app/web/templates/dashboard.html
+++ b/app/web/templates/dashboard.html
@@ -7,6 +7,9 @@
   <title>Star Citizen Trade Dashboard</title>
   <link rel="stylesheet" href="/static/styles.css" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+  {% if ctx_json %}
+  <script id="init-data" type="application/json">{{ ctx_json|safe }}</script>
+  {% endif %}
 </head>
 <body>
   <header>

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,17 @@
+import json
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.report import render_html
+
+
+def test_render_html_embeds_context(tmp_path):
+    ctx = {"kpi": {"total_profit_sc": 42}, "daily_profit": {"labels": [], "values": []},
+           "buy_summary": [], "sell_summary": [], "best_routes": [], "pending_goods": []}
+    dst = tmp_path / "report.html"
+    render_html(ctx, dst)
+    html = dst.read_text()
+    assert 'init-data' in html
+    data_start = html.find('init-data')
+    assert 'total_profit_sc' in html[data_start:]


### PR DESCRIPTION
## Summary
- embed analysis context into dashboard template for offline usage
- load the embedded data in main.js when present
- test that `render_html` injects JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865dbad51448329a31468f5cc845fd3