### PR TITLE
Fix expanding chart layout

### DIFF
--- a/app/web/static/styles.css
+++ b/app/web/static/styles.css
@@ -8,7 +8,17 @@ header { display: flex; justify-content: space-between; align-items: baseline; }
 .card { background: #161b22; border-radius: 0.75rem; padding: 1rem; box-shadow: 0 0 10px rgba(0,0,0,0.5); text-align: center; }
 .card h2 { margin: 0 0 0.5rem; font-size: 1.1rem; }
 .card p  { font-size: 1.4rem; font-weight: bold; }
-.chart { width: 100%; height: 320px; }
+.chart-container {
+  position: relative;
+  width: 100%;
+  height: 320px;
+  overflow: hidden;
+}
+.chart-container canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
 .data-table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; }
 .data-table th, .data-table td { border: 1px solid #30363d; padding: 0.25rem 0.5rem; text-align: right; }
 .data-table th { background: #21262d; }

--- a/app/web/templates/dashboard.html
+++ b/app/web/templates/dashboard.html
@@ -25,7 +25,9 @@
   </section>
 
   <!-- Chart -->
-  <canvas id="profitChart" class="chart"></canvas>
+  <div class="chart-container">
+    <canvas id="profitChart" class="chart" height="320"></canvas>
+  </div>
 
   <!-- Tables -->
   <section>


### PR DESCRIPTION
## Summary
- ensure profit chart container height stays fixed
- add height attribute to chart canvas
- keep chart container from overflowing its space

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865e0ea789c83299ae6dabb50c10d2d