### PR TITLE
Move Pending Inventory table to top

### DIFF
--- a/app/web/templates/dashboard.html
+++ b/app/web/templates/dashboard.html
@@ -31,6 +31,10 @@
 
   <!-- Tables -->
   <section>
+    <h2>Pending Inventory</h2>
+    <table id="pendingTable" class="data-table"></table>
+  </section>
+  <section>
     <h2>Buy Summary</h2>
     <table id="buyTable" class="data-table"></table>
   </section>
@@ -41,10 +45,6 @@
   <section>
     <h2>Best Routes</h2>
     <table id="routeTable" class="data-table"></table>
-  </section>
-  <section>
-    <h2>Pending Inventory</h2>
-    <table id="pendingTable" class="data-table"></table>
   </section>
 
   <script src="/static/main.js"></script>


### PR DESCRIPTION
## Summary
- reorder the Pending Inventory section above other tables in the dashboard template

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865ff1789b883298735151d5b099061