### PR TITLE
Use shopId for trade operations

### DIFF
--- a/app/analysis.py
+++ b/app/analysis.py
@@ -25,10 +25,10 @@ def _best_routes(buys: pd.DataFrame, sells: pd.DataFrame, top_n: int = 5) -> pd.
     sell_unit = sells.assign(unit_price=sells.amount / sells.quantity)
 
     buy_avg = (
-        buy_unit.groupby(["resourceGUID", "shopName"]).unit_price.mean().reset_index()
+        buy_unit.groupby(["resourceGUID", "shopId"]).unit_price.mean().reset_index()
     )
     sell_avg = (
-        sell_unit.groupby(["resourceGUID", "shopName"]).unit_price.mean().reset_index()
+        sell_unit.groupby(["resourceGUID", "shopId"]).unit_price.mean().reset_index()
     )
 
     routes = []
@@ -43,8 +43,8 @@ def _best_routes(buys: pd.DataFrame, sells: pd.DataFrame, top_n: int = 5) -> pd.
         routes.append(
             {
                 "resourceGUID": res,
-                "buyShop": best_buy.shopName,
-                "sellShop": best_sell.shopName,
+                "buyShopId": best_buy.shopId,
+                "sellShopId": best_sell.shopId,
                 "profitPerUnit": float(profit),
             }
         )
@@ -112,7 +112,7 @@ def _summary_table_buy(buys: pd.DataFrame) -> pd.DataFrame:
     if buys.empty:
         return pd.DataFrame()
     return (
-        buys.groupby(["shopName", "resourceGUID"])
+        buys.groupby(["shopId", "resourceGUID"])
         .agg(
             minQuantity=("quantity", "min"),
             avgQuantity=("quantity", "mean"),
@@ -131,7 +131,7 @@ def _summary_table_sell(sells: pd.DataFrame) -> pd.DataFrame:
     sells = sells.copy()
     sells["amountSell"] = sells.amount / sells.quantity
     return (
-        sells.groupby(["shopName", "resourceGUID"])
+        sells.groupby(["shopId", "resourceGUID"])
         .agg(
             minQuantity=("quantity", "min"),
             avgQuantity=("quantity", "mean"),

--- a/app/log_parser.py
+++ b/app/log_parser.py
@@ -46,6 +46,7 @@ def _parse_line(line: str) -> dict | None:
                 m.group("ts"), "%Y-%m-%dT%H:%M:%S.%fZ"
             ),
             "operation": op,
+            "shopId": fields.get("shopId", ""),
             "shopName": fields.get("shopName", ""),
             "resourceGUID": fields.get("resourceGUID", ""),
             "quantity": quantity,

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -9,7 +9,7 @@ from app.analysis import analyse
 
 
 def test_analyse_empty():
-    df = pd.DataFrame(columns=["timestamp", "operation", "shopName", "resourceGUID", "quantity", "shopPricePerCentiSCU", "price", "amount"])
+    df = pd.DataFrame(columns=["timestamp", "operation", "shopId", "shopName", "resourceGUID", "quantity", "shopPricePerCentiSCU", "price", "amount"])
     ctx = analyse(df)
     assert ctx["kpi"]["total_profit_sc"] == 0
     assert ctx["kpi"]["total_buys"] == 0
@@ -22,6 +22,7 @@ def test_analyse_basic_profit():
         {
             "timestamp": pd.Timestamp("2025-01-01T10:00:00Z"),
             "operation": "Buy",
+            "shopId": "ID1",
             "shopName": "ShopA",
             "resourceGUID": "res1",
             "quantity": Decimal("10"),
@@ -32,6 +33,7 @@ def test_analyse_basic_profit():
         {
             "timestamp": pd.Timestamp("2025-01-02T10:00:00Z"),
             "operation": "Sell",
+            "shopId": "ID2",
             "shopName": "ShopB",
             "resourceGUID": "res1",
             "quantity": Decimal("10"),


### PR DESCRIPTION
## Summary
- track `shopId` when parsing logs
- compute buy/sell summaries and routes grouped by `shopId`
- adjust tests for new field

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68660c8a63508329abb5efe2ed72f352