### PR TITLE
Add last transactions table with shop name mapping

### DIFF
--- a/app/web/static/main.js
+++ b/app/web/static/main.js
@@ -6,12 +6,25 @@ const resourceNames = {
   "res1": "Test Resource"
 };
 
+const shopNames = {
+  // Predefined mappings for common shops
+  "ID1": "Test Shop"
+};
+
 Object.assign(resourceNames, JSON.parse(localStorage.getItem("resourceNames") || "{}"));
+Object.assign(shopNames, JSON.parse(localStorage.getItem("shopNames") || "{}"));
 
 function saveResourceName(guid, name) {
   if (!name) return;
   resourceNames[guid] = name;
   localStorage.setItem("resourceNames", JSON.stringify(resourceNames));
+  if (lastData) updateDashboard(lastData);
+}
+
+function saveShopName(id, name) {
+  if (!name) return;
+  shopNames[id] = name;
+  localStorage.setItem("shopNames", JSON.stringify(shopNames));
   if (lastData) updateDashboard(lastData);
 }
 
@@ -57,6 +70,7 @@ function updateDashboard(data) {
   populateTable("sellTable",   data.sell_summary);
   populateTable("routeTable",  data.best_routes);
   populateTable("pendingTable", data.pending_goods);
+  populateTable("lastTransTable", data.last_transactions);
 }
 
 const initEl = document.getElementById('init-data');
@@ -95,6 +109,22 @@ function populateTable(id, rows) {
           const btn = document.createElement("button");
           btn.textContent = "Apply";
           btn.onclick = () => saveResourceName(v, input.value || v);
+          cell.appendChild(input);
+          cell.appendChild(btn);
+        } else {
+          cell.textContent = v;
+        }
+      } else if (key === "shopId") {
+        const mapped = shopNames[v];
+        if (mapped) {
+          cell.textContent = mapped;
+        } else if (id === "lastTransTable") {
+          const input = document.createElement("input");
+          input.type = "text";
+          input.placeholder = v;
+          const btn = document.createElement("button");
+          btn.textContent = "Apply";
+          btn.onclick = () => saveShopName(v, input.value || v);
           cell.appendChild(input);
           cell.appendChild(btn);
         } else {

--- a/app/web/static/styles.css
+++ b/app/web/static/styles.css
@@ -52,7 +52,8 @@ header { display: flex; justify-content: space-between; align-items: baseline; }
 }
 
 /* Pending Inventory input boxes and Apply buttons */
-#pendingTable input[type="text"] {
+#pendingTable input[type="text"],
+#lastTransTable input[type="text"] {
   background: #161b22;
   border: 1px solid #30363d;
   color: #e6edf3;
@@ -61,7 +62,8 @@ header { display: flex; justify-content: space-between; align-items: baseline; }
   margin-right: 0.25rem;
 }
 
-#pendingTable button {
+#pendingTable button,
+#lastTransTable button {
   background: #238636;
   color: #e6edf3;
   border: none;
@@ -71,6 +73,7 @@ header { display: flex; justify-content: space-between; align-items: baseline; }
   cursor: pointer;
 }
 
-#pendingTable button:hover {
+#pendingTable button:hover,
+#lastTransTable button:hover {
   background: #2ea043;
 }

--- a/app/web/templates/dashboard.html
+++ b/app/web/templates/dashboard.html
@@ -46,6 +46,10 @@
     <h2>Best Routes</h2>
     <table id="routeTable" class="data-table"></table>
   </section>
+  <section>
+    <h2>Últimas Transacciones</h2>
+    <table id="lastTransTable" class="data-table"></table>
+  </section>
 
   <script src="/static/main.js"></script>
 </body>

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -51,3 +51,6 @@ def test_analyse_basic_profit():
     assert ctx["daily_profit"]["values"] == [-100000.0, 150000.0]
     assert ctx["best_routes"][0]["profitPerUnit"] == 5000.0
     assert ctx["pending_goods"] == []
+    last = {rec["shopId"]: rec["operation"] for rec in ctx["last_transactions"]}
+    assert last["ID1"] == "Buy"
+    assert last["ID2"] == "Sell"


### PR DESCRIPTION
## Summary
- compute last transaction per shop in analysis
- display new `Últimas Transacciones` table in dashboard
- allow mapping shopIds to friendly names with a text input and button
- style new mapping UI
- cover new data with tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68660ebbddfc8329aa097373b08caa3b