### PR TITLE
Add suggested shop for pending goods

### DIFF
--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -54,3 +54,51 @@ def test_analyse_basic_profit():
     last = {rec["shopId"]: rec["operation"] for rec in ctx["last_transactions"]}
     assert last["ID1"] == "Buy"
     assert last["ID2"] == "Sell"
+
+
+def test_pending_inventory_and_suggested_shop():
+    data = [
+        {
+            "timestamp": pd.Timestamp("2025-02-01T10:00:00Z"),
+            "operation": "Buy",
+            "shopId": "B1",
+            "shopName": "BuyShop",
+            "resourceGUID": "res2",
+            "quantity": Decimal("10"),
+            "shopPricePerCentiSCU": Decimal("100"),
+            "price": Decimal("1000"),
+            "amount": Decimal("0"),
+        },
+        {
+            "timestamp": pd.Timestamp("2025-02-02T10:00:00Z"),
+            "operation": "Sell",
+            "shopId": "S1",
+            "shopName": "SellLow",
+            "resourceGUID": "res2",
+            "quantity": Decimal("4"),
+            "shopPricePerCentiSCU": Decimal("0"),
+            "price": Decimal("0"),
+            "amount": Decimal("600"),
+        },
+        {
+            "timestamp": pd.Timestamp("2025-02-03T10:00:00Z"),
+            "operation": "Sell",
+            "shopId": "S2",
+            "shopName": "SellHigh",
+            "resourceGUID": "res2",
+            "quantity": Decimal("2"),
+            "shopPricePerCentiSCU": Decimal("0"),
+            "price": Decimal("0"),
+            "amount": Decimal("400"),
+        },
+    ]
+
+    df = pd.DataFrame(data)
+    ctx = analyse(df)
+    pending = ctx["pending_goods"]
+    assert len(pending) == 1
+    rec = pending[0]
+    assert rec["resourceGUID"] == "res2"
+    assert rec["pending_qty"] == 4
+    assert rec["pending_uec"] == 400
+    assert rec["suggested shopId"] == "S2"


### PR DESCRIPTION
## Summary
- add 'suggested shopId' recommendation in pending inventory
- rename pending_cost_sc to pending_uec in pending inventory calculations
- test pending inventory logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68661ac2ae8083299abfc7e2641f1ea1