### PR TITLE
Make log root configurable and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ pip install -r requirements.txt
 ```
 
 2. Run the API locally
+Set the `LOG_ROOT` environment variable to your Star Citizen installation path:
 ```bash
-uvicorn app.web.main:app --reload
+LOG_ROOT="/path/to/StarCitizen/LIVE" uvicorn app.web.main:app --reload
 ```
 
 3. Generate an HTML report from logs

--- a/app/web/main.py
+++ b/app/web/main.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import os
 from fastapi.templating import Jinja2Templates
 from fastapi.responses import HTMLResponse
 from fastapi import Request
@@ -14,7 +15,10 @@ from ..analysis import analyse
 templates = Jinja2Templates(directory=Path(__file__).parent / "templates")
 
 LOG_ROOT = Path(
-    r"C:/Program Files/Roberts Space Industries/StarCitizen/LIVE"
+    os.getenv(
+        "LOG_ROOT",
+        r"C:/Program Files/Roberts Space Industries/StarCitizen/LIVE",
+    )
 )  # configurable
 
 @asynccontextmanager


### PR DESCRIPTION
## Summary
- allow configuring the log root via the `LOG_ROOT` environment variable
- document the `LOG_ROOT` variable in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68662b7549808329a0afd0a8dd7f31a1