### PR TITLE
Enhance dashboard layout with Bootstrap

### DIFF
--- a/app/web/templates/dashboard.html
+++ b/app/web/templates/dashboard.html
@@ -5,6 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Star Citizen Trade Dashboard</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/static/styles.css" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
   {% if ctx_json %}
@@ -12,21 +13,32 @@
   {% endif %}
 </head>
 <body>
-  <header>
+  <div class="container">
+  <header class="d-flex justify-content-between align-items-baseline">
     <h1>Star Citizen Trade Dashboard</h1>
     <small id="last-update">waiting for data…</small>
   </header>
 
   <!-- KPI cards -->
-  <section class="cards">
-    <div class="card kpi"><h2>Total Profit</h2><p id="profit">–</p></div>
-    <div class="card kpi"><h2>Total Buys</h2><p id="buys">–</p></div>
-    <div class="card kpi"><h2>Total Sells</h2><p id="sells">–</p></div>
-  </section>
+  <div class="row g-3 my-3">
+    <div class="col">
+      <div class="card kpi"><h2>Total Profit</h2><p id="profit">–</p></div>
+    </div>
+    <div class="col">
+      <div class="card kpi"><h2>Total Buys</h2><p id="buys">–</p></div>
+    </div>
+    <div class="col">
+      <div class="card kpi"><h2>Total Sells</h2><p id="sells">–</p></div>
+    </div>
+  </div>
 
   <!-- Chart -->
-  <div class="chart-container">
-    <canvas id="profitChart" class="chart" height="320"></canvas>
+  <div class="row">
+    <div class="col">
+      <div class="chart-container">
+        <canvas id="profitChart" class="chart" height="320"></canvas>
+      </div>
+    </div>
   </div>
 
   <!-- Tables -->
@@ -51,6 +63,8 @@
     <table id="lastTransTable" class="data-table"></table>
   </section>
 
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5/dist/js/bootstrap.bundle.min.js"></script>
   <script src="/static/main.js"></script>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Bootstrap 5 styles and JS bundle
- refactor dashboard markup to use Bootstrap grid classes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68663448cac08329bcd851483038c188