### PR TITLE
Update navbar and cleanup styles

### DIFF
--- a/app/web/static/styles.css
+++ b/app/web/static/styles.css
@@ -3,7 +3,6 @@ body {
   margin: 0; padding: 0 1rem;
   background: #0d1117; color: #e6edf3;
 }
-header { display: flex; justify-content: space-between; align-items: baseline; }
 .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin: 1rem 0; }
 .card { background: #161b22; border-radius: 0.75rem; padding: 1rem; box-shadow: 0 0 10px rgba(0,0,0,0.5); text-align: center; }
 .card h2 { margin: 0 0 0.5rem; font-size: 1.1rem; }

--- a/app/web/templates/dashboard.html
+++ b/app/web/templates/dashboard.html
@@ -14,9 +14,15 @@
 </head>
 <body>
   <div class="container">
-  <header class="d-flex justify-content-between align-items-baseline">
-    <h1>Star Citizen Trade Dashboard</h1>
-    <small id="last-update">waiting for data…</small>
+  <header>
+    <nav class="navbar navbar-dark bg-dark d-flex w-100">
+      <span class="navbar-brand mb-0 h1">Star Citizen Trade Dashboard</span>
+      <ul class="navbar-nav flex-row">
+        <li class="nav-item"><a class="nav-link" href="#">Nav&nbsp;1</a></li>
+        <li class="nav-item"><a class="nav-link" href="#">Nav&nbsp;2</a></li>
+      </ul>
+      <small id="last-update" class="ms-auto text-white">waiting for data…</small>
+    </nav>
   </header>
 
   <!-- KPI cards -->


### PR DESCRIPTION
## Summary
- switch header markup to Bootstrap navbar with placeholder items
- move last-update label to the navbar using `ms-auto`
- remove redundant header style

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686635a977cc8329bcb8f47c6809889a