### PR TITLE
Switch tables to Bootstrap styles

### DIFF
--- a/app/web/static/styles.css
+++ b/app/web/static/styles.css
@@ -17,37 +17,6 @@ body {
   width: 100%;
   height: 100%;
 }
-.data-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin-top: 0.5rem;
-  background-color: #0f131a;
-  color: #e6edf3;
-  font-size: 0.9rem;
-}
-
-.data-table th,
-.data-table td {
-  border: 1px solid #30363d;
-  padding: 0.5rem 0.75rem;
-  text-align: right;
-}
-
-.data-table th {
-  background: #141820;
-  color: #58a6ff;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  font-weight: 600;
-}
-
-.data-table tr:nth-child(even) {
-  background-color: rgba(255, 255, 255, 0.03);
-}
-
-.data-table tr:hover {
-  background-color: rgba(88, 166, 255, 0.1);
-}
 
 /* Pending Inventory input boxes and Apply buttons */
 #pendingTable input[type="text"],

--- a/app/web/templates/dashboard.html
+++ b/app/web/templates/dashboard.html
@@ -65,23 +65,23 @@
   <!-- Tables -->
   <section>
     <h2>Pending Inventory</h2>
-    <table id="pendingTable" class="data-table"></table>
+    <table id="pendingTable" class="table table-dark table-striped table-hover"></table>
   </section>
   <section>
     <h2>Buy Summary</h2>
-    <table id="buyTable" class="data-table"></table>
+    <table id="buyTable" class="table table-dark table-striped table-hover"></table>
   </section>
   <section>
     <h2>Sell Summary</h2>
-    <table id="sellTable" class="data-table"></table>
+    <table id="sellTable" class="table table-dark table-striped table-hover"></table>
   </section>
   <section>
     <h2>Best Routes</h2>
-    <table id="routeTable" class="data-table"></table>
+    <table id="routeTable" class="table table-dark table-striped table-hover"></table>
   </section>
   <section>
     <h2>Últimas Transacciones</h2>
-    <table id="lastTransTable" class="data-table"></table>
+    <table id="lastTransTable" class="table table-dark table-striped table-hover"></table>
   </section>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- apply Bootstrap styling to dashboard tables
- drop redundant `.data-table` CSS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866393074c08329934f4b419965107c