### PR TITLE
Improve edit inputs with Bootstrap

### DIFF
--- a/app/web/static/main.js
+++ b/app/web/static/main.js
@@ -31,12 +31,19 @@ function saveShopName(id, name) {
 function enableEdit(cell, idValue, currentName, saveFn) {
   cell.ondblclick = () => {
     cell.innerHTML = "";
+
+    const group = document.createElement("div");
+    group.className = "input-group input-group-sm";
+
     const input = document.createElement("input");
     input.type = "text";
     input.placeholder = idValue;
     input.value = currentName || "";
+    input.className = "form-control";
+
     const btn = document.createElement("button");
     btn.textContent = "Apply";
+    btn.className = "btn btn-success";
     btn.onclick = () => {
       const val = input.value.trim();
       if (val && val !== currentName && val !== idValue) {
@@ -46,8 +53,11 @@ function enableEdit(cell, idValue, currentName, saveFn) {
         enableEdit(cell, idValue, currentName, saveFn);
       }
     };
-    cell.appendChild(input);
-    cell.appendChild(btn);
+
+    group.appendChild(input);
+    group.appendChild(btn);
+    cell.appendChild(group);
+
     input.focus();
   };
 }
@@ -128,14 +138,22 @@ function populateTable(id, rows) {
           cell.textContent = mapped;
           enableEdit(cell, v, mapped, saveResourceName);
         } else if (id === "pendingTable") {
+          const group = document.createElement("div");
+          group.className = "input-group input-group-sm";
+
           const input = document.createElement("input");
           input.type = "text";
           input.placeholder = v;
+          input.className = "form-control";
+
           const btn = document.createElement("button");
           btn.textContent = "Apply";
+          btn.className = "btn btn-success";
           btn.onclick = () => saveResourceName(v, input.value || v);
-          cell.appendChild(input);
-          cell.appendChild(btn);
+
+          group.appendChild(input);
+          group.appendChild(btn);
+          cell.appendChild(group);
         } else {
           cell.textContent = v;
           enableEdit(cell, v, "", saveResourceName);
@@ -146,14 +164,22 @@ function populateTable(id, rows) {
           cell.textContent = mapped;
           enableEdit(cell, v, mapped, saveShopName);
         } else if (id === "lastTransTable") {
+          const group = document.createElement("div");
+          group.className = "input-group input-group-sm";
+
           const input = document.createElement("input");
           input.type = "text";
           input.placeholder = v;
+          input.className = "form-control";
+
           const btn = document.createElement("button");
           btn.textContent = "Apply";
+          btn.className = "btn btn-success";
           btn.onclick = () => saveShopName(v, input.value || v);
-          cell.appendChild(input);
-          cell.appendChild(btn);
+
+          group.appendChild(input);
+          group.appendChild(btn);
+          cell.appendChild(group);
         } else {
           cell.textContent = v;
           enableEdit(cell, v, "", saveShopName);

--- a/app/web/static/styles.css
+++ b/app/web/static/styles.css
@@ -18,29 +18,3 @@ body {
   height: 100%;
 }
 
-/* Pending Inventory input boxes and Apply buttons */
-#pendingTable input[type="text"],
-#lastTransTable input[type="text"] {
-  background: #161b22;
-  border: 1px solid #30363d;
-  color: #e6edf3;
-  border-radius: 4px;
-  padding: 2px 4px;
-  margin-right: 0.25rem;
-}
-
-#pendingTable button,
-#lastTransTable button {
-  background: #238636;
-  color: #e6edf3;
-  border: none;
-  border-radius: 4px;
-  padding: 2px 6px;
-  margin-left: 0.25rem;
-  cursor: pointer;
-}
-
-#pendingTable button:hover,
-#lastTransTable button:hover {
-  background: #2ea043;
-}


### PR DESCRIPTION
## Summary
- apply Bootstrap classes to edit inputs and buttons
- wrap controls in `.input-group`
- remove custom CSS for edit inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68663a0f82cc8329bdb5e2849b39e13a