### PR TITLE
Improve navigation and readability

### DIFF
--- a/app/web/static/styles.css
+++ b/app/web/static/styles.css
@@ -18,3 +18,9 @@ body {
   height: 100%;
 }
 
+/* Improve KPI readability */
+.kpi .card-title,
+.kpi .card-text {
+  color: #fff;
+}
+

--- a/app/web/templates/dashboard.html
+++ b/app/web/templates/dashboard.html
@@ -15,12 +15,15 @@
 <body>
   <div class="container">
   <header>
-    <nav class="navbar navbar-dark bg-dark d-flex w-100">
-      <span class="navbar-brand mb-0 h1">Star Citizen Trade Dashboard</span>
+    <nav class="navbar navbar-dark bg-dark d-flex w-100 position-relative">
       <ul class="navbar-nav flex-row">
-        <li class="nav-item"><a class="nav-link" href="#">Nav&nbsp;1</a></li>
-        <li class="nav-item"><a class="nav-link" href="#">Nav&nbsp;2</a></li>
+        <li class="nav-item"><a class="nav-link" href="#pending">Pending</a></li>
+        <li class="nav-item"><a class="nav-link" href="#buy-summary">Buys</a></li>
+        <li class="nav-item"><a class="nav-link" href="#sell-summary">Sells</a></li>
+        <li class="nav-item"><a class="nav-link" href="#best-routes">Routes</a></li>
+        <li class="nav-item"><a class="nav-link" href="#last-transactions">Recent</a></li>
       </ul>
+      <span class="navbar-brand mb-0 h1 position-absolute start-50 translate-middle-x">Star Citizen Trade Dashboard</span>
       <small id="last-update" class="ms-auto text-white">waiting for data…</small>
     </nav>
   </header>
@@ -63,23 +66,23 @@
   </div>
 
   <!-- Tables -->
-  <section>
+  <section id="pending">
     <h2>Pending Inventory</h2>
     <table id="pendingTable" class="table table-dark table-striped table-hover"></table>
   </section>
-  <section>
+  <section id="buy-summary">
     <h2>Buy Summary</h2>
     <table id="buyTable" class="table table-dark table-striped table-hover"></table>
   </section>
-  <section>
+  <section id="sell-summary">
     <h2>Sell Summary</h2>
     <table id="sellTable" class="table table-dark table-striped table-hover"></table>
   </section>
-  <section>
+  <section id="best-routes">
     <h2>Best Routes</h2>
     <table id="routeTable" class="table table-dark table-striped table-hover"></table>
   </section>
-  <section>
+  <section id="last-transactions">
     <h2>Últimas Transacciones</h2>
     <table id="lastTransTable" class="table table-dark table-striped table-hover"></table>
   </section>


### PR DESCRIPTION
## Summary
- add anchor links in navigation bar for page sections
- center dashboard title and adjust last-updated label
- ensure KPI text remains readable on dark background

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68663ba77d9483298df8c5e8160e77b7