### PR TITLE
Add Bootswatch Slate styling

### DIFF
--- a/app/web/static/styles.css
+++ b/app/web/static/styles.css
@@ -1,14 +1,4 @@
-body {
-  font-family: system-ui, sans-serif;
-  margin: 0; padding: 0 1rem;
-  background: #0d1117; color: #e6edf3;
+.chart {
+  width: 100%;
+  height: 320px;
 }
-header { display: flex; justify-content: space-between; align-items: baseline; }
-.cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin: 1rem 0; }
-.card { background: #161b22; border-radius: 0.75rem; padding: 1rem; box-shadow: 0 0 10px rgba(0,0,0,0.5); text-align: center; }
-.card h2 { margin: 0 0 0.5rem; font-size: 1.1rem; }
-.card p  { font-size: 1.4rem; font-weight: bold; }
-.chart { width: 100%; height: 320px; }
-.data-table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; }
-.data-table th, .data-table td { border: 1px solid #30363d; padding: 0.25rem 0.5rem; text-align: right; }
-.data-table th { background: #21262d; }

--- a/app/web/templates/dashboard.html
+++ b/app/web/templates/dashboard.html
@@ -5,43 +5,79 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Star Citizen Trade Dashboard</title>
+  <!-- Bootswatch Slate theme -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/slate/bootstrap.min.css">
   <link rel="stylesheet" href="/static/styles.css" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
 </head>
-<body>
-  <header>
-    <h1>Star Citizen Trade Dashboard</h1>
-    <small id="last-update">waiting for data…</small>
-  </header>
+<body class="bg-dark text-light">
+  <div class="container py-3">
+    <header class="d-flex justify-content-between align-items-baseline mb-4">
+      <h1 class="h3 mb-0">Star Citizen Trade Dashboard</h1>
+      <small id="last-update" class="text-muted">waiting for data…</small>
+    </header>
 
   <!-- KPI cards -->
-  <section class="cards">
-    <div class="card kpi"><h2>Total Profit</h2><p id="profit">–</p></div>
-    <div class="card kpi"><h2>Total Buys</h2><p id="buys">–</p></div>
-    <div class="card kpi"><h2>Total Sells</h2><p id="sells">–</p></div>
-  </section>
+  <div class="row row-cols-1 row-cols-md-3 g-3 mb-4">
+    <div class="col">
+      <div class="card text-center">
+        <div class="card-body">
+          <h5 class="card-title">Total Profit</h5>
+          <p id="profit" class="card-text fs-4">–</p>
+        </div>
+      </div>
+    </div>
+    <div class="col">
+      <div class="card text-center">
+        <div class="card-body">
+          <h5 class="card-title">Total Buys</h5>
+          <p id="buys" class="card-text fs-4">–</p>
+        </div>
+      </div>
+    </div>
+    <div class="col">
+      <div class="card text-center">
+        <div class="card-body">
+          <h5 class="card-title">Total Sells</h5>
+          <p id="sells" class="card-text fs-4">–</p>
+        </div>
+      </div>
+    </div>
+  </div>
 
   <!-- Chart -->
-  <canvas id="profitChart" class="chart"></canvas>
+  <div class="mb-4">
+    <canvas id="profitChart" class="chart"></canvas>
+  </div>
 
   <!-- Tables -->
-  <section>
-    <h2>Buy Summary</h2>
-    <table id="buyTable" class="data-table"></table>
+  <section class="mb-4">
+    <h2 class="h5">Buy Summary</h2>
+    <div class="table-responsive">
+      <table id="buyTable" class="table table-dark table-striped table-bordered table-sm"></table>
+    </div>
   </section>
-  <section>
-    <h2>Sell Summary</h2>
-    <table id="sellTable" class="data-table"></table>
+  <section class="mb-4">
+    <h2 class="h5">Sell Summary</h2>
+    <div class="table-responsive">
+      <table id="sellTable" class="table table-dark table-striped table-bordered table-sm"></table>
+    </div>
   </section>
-  <section>
-    <h2>Best Routes</h2>
-    <table id="routeTable" class="data-table"></table>
+  <section class="mb-4">
+    <h2 class="h5">Best Routes</h2>
+    <div class="table-responsive">
+      <table id="routeTable" class="table table-dark table-striped table-bordered table-sm"></table>
+    </div>
   </section>
-  <section>
-    <h2>Pending Inventory</h2>
-    <table id="pendingTable" class="data-table"></table>
+  <section class="mb-4">
+    <h2 class="h5">Pending Inventory</h2>
+    <div class="table-responsive">
+      <table id="pendingTable" class="table table-dark table-striped table-bordered table-sm"></table>
+    </div>
   </section>
+  </div> <!-- /container -->
 
   <script src="/static/main.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- adopt Bootstrap 5 with Bootswatch Slate theme
- restyle dashboard cards and tables using Bootstrap classes
- trim custom styles to chart height

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686797fbe39c8329be8a758f0073871c