### PR TITLE
Add Move/Stock log markers

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -2,6 +2,8 @@ from decimal import Decimal
 
 BUY_MARK = "<CEntityComponentCommodityUIProvider::SendCommodityBuyRequest>"
 SELL_MARK = "<CEntityComponentCommodityUIProvider::SendCommoditySellRequest>"
+MOVE_MARK = "<CEntityComponentCommodityUIProvider::SendCommodityMoveRequest>"
+STOCK_MARK = "<CEntityComponentCommodityUIProvider::SendCommodityStockRequest>"
 
 LINE_RE = (
     r"^<?"

--- a/app/log_parser.py
+++ b/app/log_parser.py
@@ -5,7 +5,15 @@ from pathlib import Path
 from datetime import datetime
 from decimal import Decimal
 
-from .config import BUY_MARK, SELL_MARK, LINE_RE, FIELD_RE, PRICE_FACTOR
+from .config import (
+    BUY_MARK,
+    SELL_MARK,
+    MOVE_MARK,
+    STOCK_MARK,
+    LINE_RE,
+    FIELD_RE,
+    PRICE_FACTOR,
+)
 
 __all__ = ["collect_files", "iter_records"]
 
@@ -25,14 +33,23 @@ def decode_bytes(raw: bytes) -> str:
 
 
 def _parse_line(line: str) -> dict | None:
-    if BUY_MARK not in line and SELL_MARK not in line:
+    if not any(mark in line for mark in (BUY_MARK, SELL_MARK, MOVE_MARK, STOCK_MARK)):
         return None
     m = re.match(LINE_RE, line)
     if not m:
         return None
 
     msg = m.group("msg")
-    op = "Buy" if BUY_MARK in msg else "Sell"
+    if BUY_MARK in msg:
+        op = "Buy"
+    elif SELL_MARK in msg:
+        op = "Sell"
+    elif MOVE_MARK in msg:
+        op = "Move"
+    elif STOCK_MARK in msg:
+        op = "Stock"
+    else:
+        return None
 
     fields = {k: v for k, v in re.findall(FIELD_RE, msg)}
     try:

--- a/tests/test_log_parser.py
+++ b/tests/test_log_parser.py
@@ -10,6 +10,10 @@ BUY_LINE = "<2025-06-21T22:00:18.409Z> [Notice] <CEntityComponentCommodityUIProv
 
 SELL_LINE = "<2025-06-21T22:36:46.210Z> [Notice] <CEntityComponentCommodityUIProvider::SendCommoditySellRequest> Sending SShopCommoditySellRequest - playerId[3563068139983] shopId[4511623301041] shopName[SCShop_ht_delta_shubin_m_store] kioskId[4511623301040] amount[2038501.000000] resourceGUID[096618a0-1f7d-48db-9c6a-9ac459386527] autoLoading[0] quantity[96] transactionMode[Location] Cargo Box Data:  [boxSize[8] | unitAmount[12]] [Team_CoreGameplayFeatures][Shops][UI]"
 
+MOVE_LINE = "<2025-06-21T23:00:00.000Z> [Notice] <CEntityComponentCommodityUIProvider::SendCommodityMoveRequest> Sending SShopCommodityMoveRequest - playerId[3563068139983] shopId[4511623301042] shopName[SCShop_ht_delta_move] kioskId[4511623301043] amount[1000.000000] resourceGUID[096618a0-1f7d-48db-9c6a-9ac459386527] autoLoading[0] quantity[10] transactionMode[Location] Cargo Box Data:  [boxSize[8] | unitAmount[1]] [Team_CoreGameplayFeatures][Shops][UI]"
+
+STOCK_LINE = "<2025-06-21T23:10:00.000Z> [Notice] <CEntityComponentCommodityUIProvider::SendCommodityStockRequest> Sending SShopCommodityStockRequest - playerId[3563068139983] shopId[4511623301044] shopName[SCShop_ht_delta_stock] kioskId[4511623301045] price[5000.000000] shopPricePerCentiSCU[50.000000] resourceGUID[096618a0-1f7d-48db-9c6a-9ac459386527] autoLoading[0] quantity[20] Cargo Box Data: boxSize[8.000000] | unitAmount[2] [Team_CoreGameplayFeatures][Shops][UI]"
+
 
 def test_parse_buy_line():
     rec = _parse_line(BUY_LINE)
@@ -26,14 +30,25 @@ def test_parse_sell_line():
     assert rec["quantity"] == Decimal("96")
 
 
+def test_parse_move_line():
+    rec = _parse_line(MOVE_LINE)
+    assert rec["operation"] == "Move"
+    assert rec["quantity"] == Decimal("10")
+
+
+def test_parse_stock_line():
+    rec = _parse_line(STOCK_LINE)
+    assert rec["operation"] == "Stock"
+    assert rec["price"] == Decimal("5000.000000")
+
+
 def test_iter_records_and_collect_files(tmp_path):
     log_file = tmp_path / "sample.log"
-    log_file.write_text(BUY_LINE + "\n" + SELL_LINE)
+    log_file.write_text("\n".join([BUY_LINE, SELL_LINE, MOVE_LINE, STOCK_LINE]))
 
     files = collect_files([str(tmp_path)])
     assert log_file in files
 
     records = list(iter_records(files))
-    assert len(records) == 2
-    assert records[0]["operation"] == "Buy"
-    assert records[1]["operation"] == "Sell"
+    assert len(records) == 4
+    assert [rec["operation"] for rec in records] == ["Buy", "Sell", "Move", "Stock"]


### PR DESCRIPTION
## Summary
- support parsing Move and Stock log entries
- add Move/Stock sample lines to tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686890d29c1883299b04dbb24c21d2db