### PR TITLE
Add haul tracking module with tests

### DIFF
--- a/app/hauls.py
+++ b/app/hauls.py
@@ -1,0 +1,128 @@
+"""Track buy/sell moves and compute haul profits."""
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Iterable, Dict, List
+
+__all__ = ["HaulTracker", "track_hauls"]
+
+
+@dataclass
+class _Item:
+    qty: Decimal
+    unit_cost: Decimal
+    buy_shop: str
+    location: str
+    buy_ts: object  # datetime
+
+
+class HaulTracker:
+    """Maintain per-resource inventories and build haul records."""
+
+    def __init__(self) -> None:
+        self.inventory: Dict[str, List[_Item]] = defaultdict(list)
+        self.hauls: List[dict] = []
+
+    # ────────── inventory management ──────────
+    def _add_buy(self, rec: dict) -> None:
+        qty = rec["quantity"]
+        if qty <= 0:
+            return
+        unit_cost = rec["price"] / qty if qty else Decimal("0")
+        item = _Item(
+            qty=qty,
+            unit_cost=unit_cost,
+            buy_shop=rec["shopId"],
+            location=rec["shopId"],
+            buy_ts=rec["timestamp"],
+        )
+        self.inventory[rec["resourceGUID"]].append(item)
+
+    def _sell(self, rec: dict) -> None:
+        resource = rec["resourceGUID"]
+        qty = rec["quantity"]
+        if qty <= 0:
+            return
+        revenue_total = rec["amount"]
+        unit_sell = revenue_total / qty if qty else Decimal("0")
+        items = self.inventory[resource]
+        i = 0
+        while qty > 0 and i < len(items):
+            item = items[i]
+            if item.qty <= 0:
+                items.pop(i)
+                continue
+            take = item.qty if item.qty <= qty else qty
+            cost = take * item.unit_cost
+            revenue = take * unit_sell
+            self.hauls.append(
+                {
+                    "resourceGUID": resource,
+                    "buy_shop": item.buy_shop,
+                    "sell_shop": rec["shopId"],
+                    "quantity": take,
+                    "buy_price": cost,
+                    "sell_price": revenue,
+                    "profit": revenue - cost,
+                }
+            )
+            item.qty -= take
+            qty -= take
+            if item.qty == 0:
+                items.pop(i)
+            else:
+                i += 1
+        # ignore unmatched quantity
+
+    def _move(self, rec: dict) -> None:
+        resource = rec["resourceGUID"]
+        qty = rec["quantity"]
+        dest = rec["shopId"]
+        if qty <= 0:
+            return
+        items = self.inventory[resource]
+        i = 0
+        while qty > 0 and i < len(items):
+            item = items[i]
+            if item.qty <= 0:
+                items.pop(i)
+                continue
+            take = item.qty if item.qty <= qty else qty
+            if take == item.qty:
+                item.location = dest
+            else:
+                item.qty -= take
+                new_item = _Item(
+                    qty=take,
+                    unit_cost=item.unit_cost,
+                    buy_shop=item.buy_shop,
+                    location=dest,
+                    buy_ts=item.buy_ts,
+                )
+                items.insert(i + 1, new_item)
+            qty -= take
+            i += 1
+        # ignore leftover qty if move exceeds inventory
+
+    # ────────── public API ──────────
+    def process(self, rec: dict) -> None:
+        op = rec.get("operation")
+        if op == "Buy":
+            self._add_buy(rec)
+        elif op == "Sell":
+            self._sell(rec)
+        elif op == "Move":
+            self._move(rec)
+
+    def completed_hauls(self) -> List[dict]:
+        return self.hauls
+
+
+def track_hauls(records: Iterable[dict]) -> List[dict]:
+    """Process records chronologically and return haul list."""
+    tracker = HaulTracker()
+    for rec in sorted(records, key=lambda r: r["timestamp"]):
+        tracker.process(rec)
+    return tracker.completed_hauls()

--- a/tests/test_hauls.py
+++ b/tests/test_hauls.py
@@ -1,0 +1,50 @@
+from decimal import Decimal
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.hauls import track_hauls
+from app.log_parser import _parse_line, collect_files, iter_records
+from tests.test_log_parser import BUY_LINE, SELL_LINE, MOVE_LINE
+
+
+def test_basic_buy_sell():
+    records = [_parse_line(BUY_LINE), _parse_line(SELL_LINE)]
+    hauls = track_hauls(records)
+    assert len(hauls) == 1
+    h = hauls[0]
+    assert h["buy_shop"] == "4511624678944"
+    assert h["sell_shop"] == "4511623301041"
+    assert h["quantity"] == Decimal("96")
+    expected_profit = Decimal("2038501.000000") - Decimal("2159456.000000") * Decimal("96") / Decimal("120")
+    assert h["profit"] == expected_profit
+
+
+def test_move_then_sell():
+    buy = _parse_line(BUY_LINE)
+    move_line = MOVE_LINE.replace("quantity[10]", "quantity[120]")
+    move = _parse_line(move_line)
+    sell_line = (
+        SELL_LINE.replace("4511623301041", "4511623301042")
+        .replace("quantity[96]", "quantity[120]")
+        .replace("amount[2038501.000000]", "amount[2548126.250000]")
+    )
+    sell = _parse_line(sell_line)
+    hauls = track_hauls([buy, move, sell])
+    assert len(hauls) == 1
+    h = hauls[0]
+    assert h["buy_shop"] == "4511624678944"
+    assert h["sell_shop"] == "4511623301042"
+    assert h["quantity"] == Decimal("120")
+
+
+def test_hauls_from_sample_logs():
+    log_dir = Path(__file__).parent / "logs"
+    files = collect_files([str(log_dir)])
+    records = list(iter_records(files))
+    hauls = track_hauls(records)
+    assert len(hauls) == 2
+    profits = [float(h["profit"]) for h in hauls]
+    assert profits[0] == 120937.0
+    assert profits[1] == 90993.0


### PR DESCRIPTION
## Summary
- implement `app/hauls.py` for tracking buys and sells
- generate haul records via new `track_hauls` function
- verify functionality with new unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868923c5b5c83298558bbb2539393f4