### PR TITLE
Update README for FastAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # sc-trade-dashboard
 Open-source Python web dashboard that parses Star Citizen logs to visualize trading activity, profits, and commodity trends in real time.
 
-A lightweight, Flask-powered web app that turns raw Star Citizen log files into an interactive trading dashboard.
-The backend ingests your logs\Session files, computes buy/sell metrics, route profitability, and commodity price evolution with pandas; the frontend (Plotly/Dash) renders live charts, tables, and KPIs so haulers and miners can spot the most lucrative loops at a glance. Fully containerized, cross-platform, and ready for self-hosting
+A lightweight, FastAPI-powered web app that turns raw Star Citizen log files into an interactive trading dashboard.
+The backend runs as a FastAPI application (start with `uvicorn app.web.main:app`) and ingests your logs\Session files, computes buy/sell metrics, route profitability, and commodity price evolution with pandas; the frontend (Plotly/Dash) renders live charts, tables, and KPIs so haulers and miners can spot the most lucrative loops at a glance. Fully containerized, cross-platform, and ready for self-hosting
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- swap Flask reference for FastAPI in README intro
- clarify that the backend runs as a FastAPI application and show the uvicorn command

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686894a92ea88329aa63ed52ba0770fe