### PR TITLE
Update log root default and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Set the `LOG_ROOT` environment variable to your Star Citizen installation path:
 ```bash
 LOG_ROOT="/path/to/StarCitizen/LIVE" uvicorn app.web.main:app --reload
 ```
+If not set, the application defaults to `~/StarCitizen/LIVE`. On Linux and macOS
+the logs may reside under your home directory (for example
+`~/Library/Application Support/StarCitizen/LIVE`), so adjust `LOG_ROOT`
+accordingly.
 
 3. Generate an HTML report from logs
 ```bash

--- a/app/web/main.py
+++ b/app/web/main.py
@@ -14,12 +14,8 @@ from ..analysis import analyse
 
 templates = Jinja2Templates(directory=Path(__file__).parent / "templates")
 
-LOG_ROOT = Path(
-    os.getenv(
-        "LOG_ROOT",
-        r"C:/Program Files/Roberts Space Industries/StarCitizen/LIVE",
-    )
-)  # configurable
+DEFAULT_LOG_ROOT = Path.home() / "StarCitizen" / "LIVE"
+LOG_ROOT = Path(os.getenv("LOG_ROOT", str(DEFAULT_LOG_ROOT)))  # configurable
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):

--- a/tests/test_log_root.py
+++ b/tests/test_log_root.py
@@ -1,0 +1,22 @@
+import importlib
+
+from tests.test_log_parser import BUY_LINE
+
+
+def test_log_collection_respects_log_root_env(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    log_file = log_dir / "sample.log"
+    log_file.write_text(BUY_LINE)
+
+    monkeypatch.setenv("LOG_ROOT", str(log_dir))
+
+    main = importlib.reload(importlib.import_module("app.web.main"))
+
+    from app.log_parser import collect_files, iter_records
+
+    files = collect_files([str(main.LOG_ROOT)])
+    assert log_file in files
+
+    records = list(iter_records(files))
+    assert len(records) == 1


### PR DESCRIPTION
## Summary
- default to `~/StarCitizen/LIVE` log root
- document how to set `LOG_ROOT` for Linux/macOS
- test log collection when `LOG_ROOT` uses a temporary directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68689587ea6c8329b64830a6c25f074e