### PR TITLE
Add live dashboard docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,18 @@ processes a few bundled log files:
 pip install -r requirements.txt
 pytest -q
 ```
+
+## Running the Live Dashboard
+
+1. Install the requirements and set the `LOG_ROOT` environment variable to the path of your Star Citizen `LIVE` folder:
+   ```bash
+   pip install -r requirements.txt
+   export LOG_ROOT="/path/to/StarCitizen/LIVE"
+   ```
+2. Launch the FastAPI server with `uvicorn`:
+   ```bash
+   uvicorn app.web.main:app --reload
+   ```
+3. Open [http://localhost:8000](http://localhost:8000) in your browser to see real-time trading data.
+
+When new log lines are written, the server broadcasts updates over WebSockets so the tables and charts refresh automatically without a page reload.


### PR DESCRIPTION
## Summary
- document how to run the realtime dashboard using `uvicorn`
- explain that WebSocket pushes keep charts and tables up-to-date

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868970d4bb083298128e91b277c2b33