### PR TITLE
Handle absolute glob patterns for log parsing

### DIFF
--- a/app/log_parser.py
+++ b/app/log_parser.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+import glob
 from datetime import datetime
 from decimal import Decimal
 
@@ -95,7 +96,11 @@ def collect_files(inputs: list[str]) -> list[Path]:
         elif p.is_dir():
             files.extend(p.rglob("*.log"))
         else:
-            files.extend(Path().glob(p_str))
+            # glob on absolute patterns (Path.glob doesn't allow them)
+            for match in glob.glob(p_str):
+                mp = Path(match)
+                if mp.is_file() and mp.suffix.lower() == ".log":
+                    files.append(mp)
     seen, uniq = set(), []
     for f in files:
         if f not in seen:

--- a/tests/test_log_parser.py
+++ b/tests/test_log_parser.py
@@ -52,3 +52,14 @@ def test_iter_records_and_collect_files(tmp_path):
     records = list(iter_records(files))
     assert len(records) == 4
     assert [rec["operation"] for rec in records] == ["Buy", "Sell", "Move", "Stock"]
+
+
+def test_collect_files_absolute_glob(tmp_path):
+    log_file = tmp_path / "abs.log"
+    log_file.write_text(BUY_LINE)
+
+    pattern = str(tmp_path / "*.log")
+    files = collect_files([pattern])
+    assert log_file in files
+    records = list(iter_records(files))
+    assert len(records) == 1


### PR DESCRIPTION
## Summary
- allow `collect_files()` to process absolute glob patterns
- add regression test for absolute glob patterns

## Testing
- `pip install pandas jinja2 fastapi uvicorn matplotlib openpyxl -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686898449f8883299dfc37a971a784ac