### PR TITLE
Improve LOG_ROOT docs and default handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ Set the `LOG_ROOT` environment variable to your Star Citizen installation path:
 ```bash
 LOG_ROOT="/path/to/StarCitizen/LIVE" uvicorn app.web.main:app --reload
 ```
-If not set, the application defaults to `~/StarCitizen/LIVE`. On Linux and macOS
-the logs may reside under your home directory (for example
-`~/Library/Application Support/StarCitizen/LIVE`), so adjust `LOG_ROOT`
-accordingly.
+If not set, the application defaults to `~/StarCitizen/LIVE`.
+On macOS the folder is typically found under
+`$HOME/Library/Application Support/StarCitizen/LIVE` and on most Linux
+distributions under `$HOME/.local/share/StarCitizen/LIVE`.
+Set the `LOG_ROOT` environment variable to whichever location matches your
+installation before starting the server.
 
 3. Generate an HTML report from logs
 ```bash

--- a/app/web/main.py
+++ b/app/web/main.py
@@ -15,7 +15,10 @@ from ..analysis import analyse
 templates = Jinja2Templates(directory=Path(__file__).parent / "templates")
 
 DEFAULT_LOG_ROOT = Path.home() / "StarCitizen" / "LIVE"
-LOG_ROOT = Path(os.getenv("LOG_ROOT", str(DEFAULT_LOG_ROOT)))  # configurable
+# Resolve LOG_ROOT from the environment while falling back to the user's home
+# directory. ``Path`` accepts a ``Path`` instance so the default can remain a
+# ``Path`` object without string conversion.
+LOG_ROOT = Path(os.environ.get("LOG_ROOT", DEFAULT_LOG_ROOT))
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):


### PR DESCRIPTION
## Summary
- clarify LOG_ROOT fallback path in main.py
- document Linux/macOS LOG_ROOT paths in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68689f2a17e8832998f26b290cba96b6