### PR TITLE
Add tests for LOG_ROOT resolution

### DIFF
--- a/tests/test_log_root.py
+++ b/tests/test_log_root.py
@@ -1,5 +1,6 @@
 import importlib
 
+from pathlib import Path
 from tests.test_log_parser import BUY_LINE
 
 
@@ -20,3 +21,21 @@ def test_log_collection_respects_log_root_env(tmp_path, monkeypatch):
 
     records = list(iter_records(files))
     assert len(records) == 1
+
+
+def test_log_root_defaults_to_home(monkeypatch):
+    monkeypatch.delenv("LOG_ROOT", raising=False)
+
+    main = importlib.reload(importlib.import_module("app.web.main"))
+
+    expected = Path.home() / "StarCitizen" / "LIVE"
+    assert main.LOG_ROOT == expected
+
+
+def test_log_root_uses_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("LOG_ROOT", str(tmp_path))
+
+    main = importlib.reload(importlib.import_module("app.web.main"))
+
+    assert main.LOG_ROOT == tmp_path
+    assert isinstance(main.LOG_ROOT, Path)


### PR DESCRIPTION
## Summary
- add regression tests verifying LOG_ROOT defaults to ~/StarCitizen/LIVE
- check LOG_ROOT is a `Path` and respects the environment variable

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868a67caf8483299f935e5ea9410f5b