### PR TITLE
Show log summary on dashboard

### DIFF
--- a/app/web/main.py
+++ b/app/web/main.py
@@ -50,9 +50,11 @@ async def watch_logs():
     global _latest_ctx
     while True:
         try:
-            df = pd.DataFrame(iter_records(collect_files([str(LOG_ROOT)])))
-            if not df.empty:
-                _latest_ctx = analyse(df)
+            files = collect_files([str(LOG_ROOT)])
+            df = pd.DataFrame(iter_records(files))
+            ctx = analyse(df)
+            ctx["log_info"] = {"path": str(LOG_ROOT), "count": len(files)}
+            _latest_ctx = ctx
         except Exception:
             import logging
             logging.exception("Analyse failed:")

--- a/app/web/static/main.js
+++ b/app/web/static/main.js
@@ -77,6 +77,9 @@ function updateDashboard(data) {
   set("sells",  data.kpi.total_sells.toLocaleString());
   document.getElementById("last-update").textContent =
     `Updated ${new Date().toLocaleTimeString()}`;
+  if (data.log_info) {
+    document.getElementById("log-summary").textContent = `${data.log_info.count} logs from ${data.log_info.path}`;
+  }
 
   // Chart (create once, then update datasets)
   if (!chart) {

--- a/app/web/templates/dashboard.html
+++ b/app/web/templates/dashboard.html
@@ -25,6 +25,7 @@
       </ul>
       <span class="navbar-brand mb-0 h1 position-absolute start-50 translate-middle-x">Star Citizen Trade Dashboard</span>
       <small id="last-update" class="ms-auto text-white">waiting for data…</small>
+      <small id="log-summary" class="ms-2 text-white"></small>
     </nav>
   </header>
 


### PR DESCRIPTION
## Summary
- track how many log files are loaded and which path they come from
- surface this information through the API and WebSocket
- display log summary in the dashboard header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686967b245088329bf2d945c45c281e0