### PR TITLE
Fix spacing after fig_to_b64

### DIFF
--- a/app/report.py
+++ b/app/report.py
@@ -12,6 +12,7 @@ def fig_to_b64(fig) -> str:
     plt.close(fig)
     return base64.b64encode(buf.getvalue()).decode()
 
+
 HTML_TEMPLATE = Path(__file__).parent / "web" / "templates" / "dashboard.html"
 
 


### PR DESCRIPTION
## Summary
- add an extra newline after `fig_to_b64` to satisfy flake8 E305

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686981d5eb308329953b6c0df2c0b88c