### PR TITLE
Fix code style in generate_report

### DIFF
--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 """CLI wrapper to keep parity with the standalone script."""
-import argparse, logging, sys
+import argparse
+import logging
+import sys
 from pathlib import Path
 import pandas as pd
 
 from app.log_parser import collect_files, iter_records
-from app.analysis   import analyse
-from app.report     import render_html
+from app.analysis import analyse
+from app.report import render_html
 
 
 def main():
@@ -18,11 +20,13 @@ def main():
 
     files = collect_files(args.log_paths)
     if not files:
-        logging.error("No .log files found"); sys.exit(1)
+        logging.error("No .log files found")
+        sys.exit(1)
 
     df = pd.DataFrame(iter_records(files))
     if df.empty:
-        logging.error("No BUY/SELL events detected"); sys.exit(2)
+        logging.error("No BUY/SELL events detected")
+        sys.exit(2)
 
     ctx = analyse(df)
     render_html(ctx, args.output_html)
@@ -34,6 +38,7 @@ def main():
             pd.DataFrame(ctx["sell_summary"]).to_excel(xls, "SELL", index=False)
             pd.DataFrame(ctx["best_routes"]).to_excel(xls, "ROUTES", index=False)
             pd.DataFrame(ctx["pending_goods"]).to_excel(xls, "PENDING", index=False)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- tidy up imports and multi-statement lines
- add newline at EOF and spacing fixes

## Testing
- `flake8 scripts/generate_report.py | grep -E 'E401|E702|W292|E272'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686981d2c928832999ae6e09d4cb3cce