### PR TITLE
Add config.ini support

### DIFF
--- a/app/config_loader.py
+++ b/app/config_loader.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+import os
+from pathlib import Path
+import configparser
+
+CONFIG_PATH = Path.cwd() / "config.ini"
+_parser = configparser.ConfigParser()
+if CONFIG_PATH.exists():
+    _parser.read(CONFIG_PATH)
+
+__all__ = ["get_log_root", "get_database_url"]
+
+def get_log_root(default: Path) -> Path:
+    value = os.environ.get("LOG_ROOT") or _parser.get("settings", "log_root", fallback=str(default))
+    return Path(value).expanduser()
+
+def get_database_url(default: str) -> str:
+    return os.environ.get("DATABASE_URL") or _parser.get("settings", "database_url", fallback=default)

--- a/app/db.py
+++ b/app/db.py
@@ -1,8 +1,9 @@
 import os
 from sqlalchemy import create_engine, Column, String
 from sqlalchemy.orm import declarative_base, sessionmaker
+from .config_loader import get_database_url
 
-DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///./names.db")
+DATABASE_URL = get_database_url("sqlite:///./names.db")
 
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(bind=engine)

--- a/app/web/main.py
+++ b/app/web/main.py
@@ -18,14 +18,15 @@ from ..db import (
     save_resource_name,
     save_shop_name,
 )
+from ..config_loader import get_log_root
 
 templates = Jinja2Templates(directory=Path(__file__).parent / "templates")
 
 DEFAULT_LOG_ROOT = Path.home() / "StarCitizen" / "LIVE"
-# Resolve LOG_ROOT from the environment while falling back to the user's home
-# directory. ``Path`` accepts a ``Path`` instance so the default can remain a
-# ``Path`` object without string conversion.
-LOG_ROOT = Path(os.environ.get("LOG_ROOT", DEFAULT_LOG_ROOT))
+# Resolve LOG_ROOT from environment or config.ini while falling back to the
+# user's home directory. ``Path`` accepts a ``Path`` instance so the default can
+# remain a ``Path`` object without string conversion.
+LOG_ROOT = get_log_root(DEFAULT_LOG_ROOT)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,3 @@
+[settings]
+log_root = ~/StarCitizen/LIVE
+database_url = sqlite:///./names.db


### PR DESCRIPTION
## Summary
- add a repository-wide `config.ini` with sample log and db paths
- implement `config_loader` to parse settings from working directory
- load configuration values in `db.py` and `web/main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ad211e8748329ba229e2499ab284e