### PR TITLE
Add config loader docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ distributions under `$HOME/.local/share/StarCitizen/LIVE`.
 Set the `LOG_ROOT` environment variable to whichever location matches your
 installation before starting the server.
 
+Alternatively you can create a small `config.ini` file next to the code to keep
+these settings persistent:
+
+```ini
+[settings]
+log_root = /path/to/StarCitizen/LIVE
+database_url = sqlite:///./names.db
+```
+
+Values from `config.ini` are loaded automatically and may be overridden by
+environment variables at runtime.
+
 3. Generate an HTML report from logs
 ```bash
 python scripts/generate_report.py path/to/logs/*.log report.html

--- a/app/config_loader.py
+++ b/app/config_loader.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+
+"""Read configuration from ``config.ini`` and environment variables."""
+
 import os
 from pathlib import Path
 import configparser
@@ -11,8 +14,25 @@ if CONFIG_PATH.exists():
 __all__ = ["get_log_root", "get_database_url"]
 
 def get_log_root(default: Path) -> Path:
-    value = os.environ.get("LOG_ROOT") or _parser.get("settings", "log_root", fallback=str(default))
+    """Return the folder containing log files.
+
+    The value is resolved in this order:
+    1. ``LOG_ROOT`` environment variable
+    2. ``log_root`` entry under the ``[settings]`` section of ``config.ini``
+    3. ``default`` argument
+    """
+
+    value = os.environ.get("LOG_ROOT") or _parser.get(
+        "settings", "log_root", fallback=str(default)
+    )
     return Path(value).expanduser()
 
 def get_database_url(default: str) -> str:
-    return os.environ.get("DATABASE_URL") or _parser.get("settings", "database_url", fallback=default)
+    """Return the database connection URL.
+
+    Resolution order mirrors :func:`get_log_root`.
+    """
+
+    return os.environ.get("DATABASE_URL") or _parser.get(
+        "settings", "database_url", fallback=default
+    )

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,40 @@
+import importlib
+from pathlib import Path
+import sys
+import os
+
+
+def test_config_ini_read(monkeypatch, tmp_path):
+    cfg = tmp_path / "config.ini"
+    cfg.write_text(
+        """[settings]\nlog_root = /tmp/logs\ndatabase_url = sqlite:///tmp/db\n"""
+    )
+    root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(root))
+    orig_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    loader = importlib.reload(importlib.import_module("app.config_loader"))
+    assert loader.get_log_root(Path.home()) == Path("/tmp/logs")
+    assert loader.get_database_url("sqlite:///default.db") == "sqlite:///tmp/db"
+    os.chdir(orig_cwd)
+    importlib.reload(loader)
+    sys.path.remove(str(root))
+
+
+def test_env_overrides_config(monkeypatch, tmp_path):
+    cfg = tmp_path / "config.ini"
+    cfg.write_text(
+        """[settings]\nlog_root = /tmp/logs\ndatabase_url = sqlite:///tmp/db\n"""
+    )
+    root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(root))
+    orig_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    monkeypatch.setenv("LOG_ROOT", "/env/logs")
+    monkeypatch.setenv("DATABASE_URL", "postgres://u:p@localhost/db")
+    loader = importlib.reload(importlib.import_module("app.config_loader"))
+    assert loader.get_log_root(Path.home()) == Path("/env/logs")
+    assert loader.get_database_url("sqlite:///default.db") == "postgres://u:p@localhost/db"
+    os.chdir(orig_cwd)
+    importlib.reload(loader)
+    sys.path.remove(str(root))


### PR DESCRIPTION
## Summary
- document `config.ini` usage in README
- expand `app/config_loader` with module docs and comments
- add tests covering `config_loader` behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ad33070b083299d45c54540908b84