### PR TITLE
Use config loader helpers

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1,8 +1,9 @@
-import os
 from sqlalchemy import create_engine, Column, String
 from sqlalchemy.orm import declarative_base, sessionmaker
 from .config_loader import get_database_url
 
+# Resolve the database URL via ``config.ini`` or the ``DATABASE_URL`` environment
+# variable while falling back to the local SQLite database.
 DATABASE_URL = get_database_url("sqlite:///./names.db")
 
 engine = create_engine(DATABASE_URL)

--- a/app/web/main.py
+++ b/app/web/main.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import os
 from fastapi.templating import Jinja2Templates
 from fastapi.responses import HTMLResponse
 from fastapi import Request
@@ -23,9 +22,10 @@ from ..config_loader import get_log_root
 templates = Jinja2Templates(directory=Path(__file__).parent / "templates")
 
 DEFAULT_LOG_ROOT = Path.home() / "StarCitizen" / "LIVE"
-# Resolve LOG_ROOT from environment or config.ini while falling back to the
-# user's home directory. ``Path`` accepts a ``Path`` instance so the default can
-# remain a ``Path`` object without string conversion.
+# Resolve LOG_ROOT from ``config.ini`` or the ``LOG_ROOT`` environment variable
+# while falling back to the user's home directory. ``Path`` accepts a ``Path``
+# instance so the default can remain a ``Path`` object without string
+# conversion.
 LOG_ROOT = get_log_root(DEFAULT_LOG_ROOT)
 
 @asynccontextmanager


### PR DESCRIPTION
## Summary
- rework log root setup in `app/web/main.py`
- read DB URL via `get_database_url` in `app/db.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ad55039d08329ad96d4b4e901bade