### PR TITLE
Update name mapping docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ The dashboard replaces raw `resourceGUID` values with human‑readable names. A
 small dictionary of common mappings is bundled in `static/main.js`. When an
 unknown GUID appears in the **Pending Inventory** table, a text box and `Apply`
 button let you provide a custom name. The mapping is stored in your browser's
-`localStorage` and applied to all tables immediately.
+`localStorage` and applied to all tables immediately. Mappings are also
+persisted on the server in a SQLite database so they survive browser cache
+clears.
 
 ## Running Tests
 


### PR DESCRIPTION
## Summary
- clarify that custom resource mappings persist to SQLite so they survive cache clears

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686af83a1c94832991bb2491a27f4888